### PR TITLE
Fixed invalid authentication caching with multiple servers on the same host 

### DIFF
--- a/src/main/java/com/burgstaller/okhttp/AuthenticationCacheInterceptor.java
+++ b/src/main/java/com/burgstaller/okhttp/AuthenticationCacheInterceptor.java
@@ -5,6 +5,7 @@ import com.burgstaller.okhttp.digest.CachingAuthenticator;
 import java.io.IOException;
 import java.util.Map;
 
+import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -23,8 +24,9 @@ public class AuthenticationCacheInterceptor implements Interceptor {
     @Override
     public Response intercept(Chain chain) throws IOException {
         final Request request = chain.request();
-        String host = request.url().host();
-        CachingAuthenticator authenticator = authCache.get(host);
+        final HttpUrl url = request.url();
+        final String key = url.scheme() + ":" + url.host() + ":" + url.port();
+        CachingAuthenticator authenticator = authCache.get(key);
         Request authRequest = null;
         if (authenticator != null) {
             authRequest = authenticator.authenticateWithState(request);

--- a/src/main/java/com/burgstaller/okhttp/AuthenticationCacheInterceptor.java
+++ b/src/main/java/com/burgstaller/okhttp/AuthenticationCacheInterceptor.java
@@ -25,7 +25,7 @@ public class AuthenticationCacheInterceptor implements Interceptor {
     public Response intercept(Chain chain) throws IOException {
         final Request request = chain.request();
         final HttpUrl url = request.url();
-        final String key = url.scheme() + ":" + url.host() + ":" + url.port();
+        final String key = CachingUtils.getCachingKey(url);
         CachingAuthenticator authenticator = authCache.get(key);
         Request authRequest = null;
         if (authenticator != null) {

--- a/src/main/java/com/burgstaller/okhttp/CachingAuthenticatorDecorator.java
+++ b/src/main/java/com/burgstaller/okhttp/CachingAuthenticatorDecorator.java
@@ -3,6 +3,7 @@ package com.burgstaller.okhttp;
 import com.burgstaller.okhttp.digest.CachingAuthenticator;
 
 import okhttp3.Authenticator;
+import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.Route;
@@ -30,7 +31,9 @@ public class CachingAuthenticatorDecorator implements Authenticator {
         if (authenticated != null) {
             String authorizationValue = authenticated.header("Authorization");
             if (authorizationValue != null && innerAuthenticator instanceof CachingAuthenticator) {
-                authCache.put(authenticated.url().host(), (CachingAuthenticator) innerAuthenticator);
+                final HttpUrl url = authenticated.url();
+                final String key = url.scheme() + ":" + url.host() + ":" + url.port();
+                authCache.put(key, (CachingAuthenticator) innerAuthenticator);
             }
         }
         return authenticated;

--- a/src/main/java/com/burgstaller/okhttp/CachingAuthenticatorDecorator.java
+++ b/src/main/java/com/burgstaller/okhttp/CachingAuthenticatorDecorator.java
@@ -32,7 +32,7 @@ public class CachingAuthenticatorDecorator implements Authenticator {
             String authorizationValue = authenticated.header("Authorization");
             if (authorizationValue != null && innerAuthenticator instanceof CachingAuthenticator) {
                 final HttpUrl url = authenticated.url();
-                final String key = url.scheme() + ":" + url.host() + ":" + url.port();
+                final String key = CachingUtils.getCachingKey(url);
                 authCache.put(key, (CachingAuthenticator) innerAuthenticator);
             }
         }

--- a/src/main/java/com/burgstaller/okhttp/CachingUtils.java
+++ b/src/main/java/com/burgstaller/okhttp/CachingUtils.java
@@ -1,0 +1,17 @@
+package com.burgstaller.okhttp;
+
+import okhttp3.HttpUrl;
+
+public final class CachingUtils {
+
+    /**
+     * Get key to be used for storing cached auth responses, e.g.
+     * http:myhost.com:8080
+     */
+    public static String getCachingKey(HttpUrl url) {
+        if (url == null)
+            return null;
+        return url.scheme() + ":" + url.host() + ":" + url.port();
+    }
+
+}

--- a/src/test/java/com/burgstaller/okhttp/CachingTest.java
+++ b/src/test/java/com/burgstaller/okhttp/CachingTest.java
@@ -1,0 +1,99 @@
+package com.burgstaller.okhttp;
+
+import com.burgstaller.okhttp.basic.BasicAuthenticator;
+import com.burgstaller.okhttp.digest.CachingAuthenticator;
+import com.burgstaller.okhttp.digest.Credentials;
+
+import junit.framework.Assert;
+
+import org.hamcrest.text.MatchesPattern;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import okhttp3.Authenticator;
+import okhttp3.Connection;
+import okhttp3.Interceptor;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit test for authenticator caching.
+ *
+ * @author Alexey Vasilyev
+ */
+public class CachingTest {
+
+    @Test
+    public void testCaching_withDifferentPorts() throws Exception {
+        Map<String, CachingAuthenticator> authCache = new ConcurrentHashMap<>();
+
+        // Fill in authCache.
+        // https://myhost.com => basic auth user1:user1
+        Authenticator decorator = new CachingAuthenticatorDecorator(
+                new BasicAuthenticator(new Credentials("user1", "user1")),
+                authCache);
+        Request dummyRequest = new Request.Builder()
+                .url("https://myhost.com")
+                .get()
+                .build();
+        Response response = new Response.Builder()
+                .request(dummyRequest)
+                .protocol(Protocol.HTTP_1_1)
+                .code(401)
+                .header("WWW-Authenticate", "Basic realm=\"myrealm\"")
+                .build();
+        decorator.authenticate(null, response);
+        Assert.assertTrue(authCache.size() == 1);
+
+
+        Interceptor interceptor = new AuthenticationCacheInterceptor(authCache);
+
+        // Check that authenticator exists for https://myhost.com:443
+        interceptor.intercept(new Interceptor.Chain() {
+            @Override
+            public Request request() {
+                return new Request.Builder()
+                        .url("https://myhost.com:443")
+                        .get()
+                        .build();
+            }
+            @Override
+            public Response proceed(Request request) throws IOException {
+                assertThat(request.header("Authorization"), MatchesPattern.matchesPattern("Basic dXNlcjE6dXNlcjE="));
+                return null;
+            }
+            @Override
+            public Connection connection() {
+                return null;
+            }
+        });
+
+
+        // Check that authenticator does not exist for http://myhost.com:8080
+        interceptor.intercept(new Interceptor.Chain() {
+            @Override
+            public Request request() {
+                return new Request.Builder()
+                        .url("http://myhost.com:8080")
+                        .get()
+                        .build();
+            }
+            @Override
+            public Response proceed(Request request) throws IOException {
+                assertNull(request.header("Authorization"));
+                return null;
+            }
+            @Override
+            public Connection connection() {
+                return null;
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
At the moment caching authentication key is **host** name only.

However there might be several web servers on the same server located on different ports (physically or via port forwarding), e.g.
http://myhost.no-ip.org:8080
http://myhost.no-ip.org:8081
https://myhost.no-ip.org:8082

In this case all these servers will be stored under the same myhost.no-ip.org key. This will lead to 401 error for two servers.

This pull request fix this issue.
Key name is now **scheme:host:port**, e.g. http:myhost.no-ip.org:8080.
