### PR TITLE
More flexible authentication header parsing in DispatchingAuthenticator

### DIFF
--- a/src/main/java/com/burgstaller/okhttp/ChallengeParser.java
+++ b/src/main/java/com/burgstaller/okhttp/ChallengeParser.java
@@ -1,0 +1,46 @@
+package com.burgstaller.okhttp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import okhttp3.Challenge;
+import okhttp3.Headers;
+import okhttp3.Response;
+
+import static java.net.HttpURLConnection.HTTP_PROXY_AUTH;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+
+/**
+ * Challenge parser which allows parsing of Authentication headers which don't follow RFC 2617
+ * See: https://github.com/square/okhttp/issues/2780
+ *
+ * @author Lukas Aichbauer
+ */
+public final class ChallengeParser {
+    private static final Pattern AUTHENTICATION_HEADER_PATTERN = Pattern.compile("(.*?) .*?realm=\"(.*?)\"", Pattern.CASE_INSENSITIVE);
+
+    public static List<Challenge> challenges(Response response) {
+        if (response.code() == HTTP_UNAUTHORIZED) {
+            return challenges("WWW-Authenticate", response.headers());
+        } else if (response.code() == HTTP_PROXY_AUTH) {
+            return challenges("Proxy-Authenticate", response.headers());
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    public static List<Challenge> challenges(String header, Headers headers) {
+        List<Challenge> challenges = new ArrayList<>();
+        List<String> authenticationHeaders = headers.values(header);
+        for (String authenticationHeader : authenticationHeaders) {
+            Matcher matcher = AUTHENTICATION_HEADER_PATTERN.matcher(authenticationHeader);
+            if (matcher.find()) {
+                challenges.add(new Challenge(matcher.group(1), matcher.group(2)));
+            }
+        }
+        return challenges;
+    }
+}

--- a/src/main/java/com/burgstaller/okhttp/DispatchingAuthenticator.java
+++ b/src/main/java/com/burgstaller/okhttp/DispatchingAuthenticator.java
@@ -2,17 +2,17 @@ package com.burgstaller.okhttp;
 
 import com.burgstaller.okhttp.digest.CachingAuthenticator;
 
-import okhttp3.Authenticator;
-import okhttp3.Challenge;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.Route;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import okhttp3.Authenticator;
+import okhttp3.Challenge;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
 
 /**
  * A dispatching authenticator which can be used with multiple auth schemes.
@@ -33,7 +33,7 @@ public class DispatchingAuthenticator implements CachingAuthenticator {
 
     @Override
     public Request authenticate(Route route, Response response) throws IOException {
-        List<Challenge> challenges = response.challenges();
+        List<Challenge> challenges = ChallengeParser.challenges(response);
         if (!challenges.isEmpty()) {
             for (Challenge challenge : challenges) {
                 final String scheme = challenge.scheme();
@@ -73,3 +73,4 @@ public class DispatchingAuthenticator implements CachingAuthenticator {
         }
     }
 }
+

--- a/src/test/java/com/burgstaller/okhttp/WrongOrderedAuthenticationHeaderTest.java
+++ b/src/test/java/com/burgstaller/okhttp/WrongOrderedAuthenticationHeaderTest.java
@@ -1,0 +1,41 @@
+package com.burgstaller.okhttp;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+import okhttp3.Challenge;
+import okhttp3.Headers;
+import okhttp3.internal.http.HttpHeaders;
+
+/**
+ * Unit test for wrong ordered authentication header.
+ */
+public class WrongOrderedAuthenticationHeaderTest {
+    /**
+     * See: https://github.com/square/okhttp/issues/2780
+     */
+    @Test
+    public void testWrongOrderedHeader() {
+        // Strict RFC 2617 header
+        Headers headers = new Headers.Builder()
+                .add("WWW-Authenticate", "Digest realm=\"myrealm\", nonce=\"fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf\", qop=\"auth\", stale=\"FALSE\"").build();
+        List<Challenge> challenges = HttpHeaders.parseChallenges(headers, "WWW-Authenticate");
+        Assert.assertEquals(1, challenges.size());
+        Assert.assertEquals("Digest", challenges.get(0).scheme());
+        Assert.assertEquals("myrealm", challenges.get(0).realm());
+
+        // Not strict RFC 2617 header. No challenge will be found HttpHeaders.parseChallenges(...) in OkHttp 3.4.1.
+        headers = new Headers.Builder()
+                .add("WWW-Authenticate", "Digest qop=\"auth\", realm=\"myrealm\", nonce=\"fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf\", stale=\"FALSE\"").build();
+        challenges = HttpHeaders.parseChallenges(headers, "WWW-Authenticate");
+        Assert.assertEquals(0, challenges.size());
+
+        // More flexible implementation finds header
+        challenges = ChallengeParser.challenges("WWW-Authenticate", headers);
+        Assert.assertEquals(1, challenges.size());
+        Assert.assertEquals("Digest", challenges.get(0).scheme());
+        Assert.assertEquals("myrealm", challenges.get(0).realm());
+    }
+}


### PR DESCRIPTION
Removed Response.challenges() and replace by more flexible authentication header parsing.
Authentication headers with wrongly ordered parameters not following RFC 2617 were not recognized.
See: https://github.com/square/okhttp/issues/2780

Thanks for your great library!
Hopfefully you find this usefull, or at least it can give you some input for improvement.

regards
Lukas
