### PR TITLE
Update DispatchingAuthenticator.java

### DIFF
--- a/src/main/java/com/burgstaller/okhttp/DispatchingAuthenticator.java
+++ b/src/main/java/com/burgstaller/okhttp/DispatchingAuthenticator.java
@@ -46,7 +46,7 @@ public class DispatchingAuthenticator implements CachingAuthenticator {
                 }
             }
         }
-        throw new IllegalArgumentException("unsupported auth scheme " + challenges);
+        return null;
     }
 
     @Override


### PR DESCRIPTION
According to the javadoc of Authenticator, we should return null if the challenge cannot be satisfied.
Throwing an IllegalArgumentException here breaks the internal flow of OKHTTP.