### PR TITLE
fix: Add null check for inputs to Credentials.java

### DIFF
--- a/src/main/java/com/burgstaller/okhttp/digest/Credentials.java
+++ b/src/main/java/com/burgstaller/okhttp/digest/Credentials.java
@@ -8,6 +8,9 @@ public class Credentials {
     private String password;
 
     public Credentials(String userName, String password) {
+        if (userName == null || password == null) {
+            throw new IllegalArgumentException("username and password cannot be null");
+        }
         this.userName = userName;
         this.password = password;
     }

--- a/src/test/java/com/burgstaller/okhttp/basic/BasicAuthenticatorTest.java
+++ b/src/test/java/com/burgstaller/okhttp/basic/BasicAuthenticatorTest.java
@@ -5,7 +5,9 @@ import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -43,6 +45,32 @@ public class BasicAuthenticatorTest {
         Request authenticated = authenticator.authenticate(null, response);
 
         assertThat(authenticated.header("Authorization")).matches("Basic dXNlcjE6dXNlcjE=");
+    }
+
+    @Test
+    public void testNullCredentials() throws Exception {
+        //both are null
+        try {
+            Credentials creds = new Credentials(null, null);
+        } catch (Exception e) {
+            assertThat(e.getClass()).isEqualTo(IllegalArgumentException.class);
+        }
+
+        //username is null
+        try {
+            Credentials creds = new Credentials(null, "password");
+        } catch (Exception e) {
+            assertThat(e.getClass()).isEqualTo(IllegalArgumentException.class);
+        }
+
+        //password is null
+        try {
+            Credentials creds = new Credentials("username", null);
+        } catch (Exception e) {
+            assertThat(e.getClass()).isEqualTo(IllegalArgumentException.class);
+        }
+
+
     }
 
     @Test


### PR DESCRIPTION
Okhttp 4.x looks like it no longer allows [null inputs for credentials](https://square.github.io/okhttp/upgrading_to_okhttp_4/#credentialsbasic).

Passing null values into the Credentials constructor winds up with a crash once it passes these inputs into okhttp's Credentials.

This PR throws an `IllegalArgumentException` if the username or password are null when instantiating `Credentials`. Theres also a possibility of added default username + password if either are null. This would prevent callers from having to surround Credentials in a try/catch but could be looked at as a hidden side-effect