### PR TITLE
Use UTF-8 in digest auth to allow special characters like umlauts

### DIFF
--- a/src/main/java/com/burgstaller/okhttp/digest/DigestAuthenticator.java
+++ b/src/main/java/com/burgstaller/okhttp/digest/DigestAuthenticator.java
@@ -73,7 +73,7 @@ public class DigestAuthenticator implements CachingAuthenticator {
 
     public DigestAuthenticator(Credentials credentials) {
         this.credentials = credentials;
-        this.credentialsCharset = StandardCharsets.US_ASCII;
+        this.credentialsCharset = StandardCharsets.UTF_8;
     }
 
     public DigestAuthenticator(Credentials credentials, Charset credentialsCharset) {
@@ -441,7 +441,7 @@ public class DigestAuthenticator implements CachingAuthenticator {
             digestValue = sb.toString();
         }
 
-        final String digest = encode(digester.digest(getAsciiBytes(digestValue)));
+        final String digest = encode(digester.digest(getUtf8Bytes(digestValue)));
 
         final StringBuilder buffer = new StringBuilder(128);
         final String headerKey;
@@ -508,11 +508,11 @@ public class DigestAuthenticator implements CachingAuthenticator {
         }
     }
 
-    public static byte[] getAsciiBytes(String data) {
+    public static byte[] getUtf8Bytes(String data) {
         if (data == null) {
             throw new IllegalArgumentException("Parameter may not be null");
         } else {
-            return data.getBytes(StandardCharsets.US_ASCII);
+            return data.getBytes(StandardCharsets.UTF_8);
         }
     }
 


### PR DESCRIPTION
To verify the fix setup a WebDAV server using Digest auth with an umlaut as password using e.g. 

docker-compose up -f [docker-compose_digest.txt](https://github.com/rburgst/okhttp-digest/files/8712017/docker-compose_digest.txt)

Try to connect using username `alice` and password `bobü`