### PR TITLE
Throw IOException instead of IllegalArgumentException

### DIFF
--- a/src/main/java/com/burgstaller/okhttp/digest/DigestAuthenticator.java
+++ b/src/main/java/com/burgstaller/okhttp/digest/DigestAuthenticator.java
@@ -187,7 +187,7 @@ public class DigestAuthenticator implements CachingAuthenticator {
         if (authHeaders.contains("OkHttp-Preemptive")) {
             return null;
         }
-        throw new IllegalArgumentException("unsupported auth scheme: " + authHeaders);
+        throw new IOException("unsupported auth scheme: " + authHeaders);
     }
 
     @Override

--- a/src/main/java/com/burgstaller/okhttp/digest/DigestAuthenticator.java
+++ b/src/main/java/com/burgstaller/okhttp/digest/DigestAuthenticator.java
@@ -158,7 +158,7 @@ public class DigestAuthenticator implements CachingAuthenticator {
 
         // sanity check for issue #22
         if (parameters.get("nonce") == null) {
-            throw new IllegalArgumentException("missing nonce in challenge header: " + header);
+            throw new IOException("missing nonce in challenge header: " + header);
         }
 
         return authenticateWithState(route, response.request(), parameters);
@@ -176,7 +176,7 @@ public class DigestAuthenticator implements CachingAuthenticator {
         return "";
     }
 
-    private String findDigestHeader(Headers headers, String name) {
+    private String findDigestHeader(Headers headers, String name) throws IOException {
         final List<String> authHeaders = headers.values(name);
         for (String header : authHeaders) {
             if (header.startsWith("Digest")) {
@@ -208,7 +208,7 @@ public class DigestAuthenticator implements CachingAuthenticator {
         }
         final String nonce = parameters.get("nonce");
         if (nonce == null) {
-            throw new IllegalArgumentException("missing nonce in challenge");
+            throw new IOException("missing nonce in challenge");
         }
         String stale = parameters.get("stale");
         boolean isStale = "true".equalsIgnoreCase(stale);
@@ -525,7 +525,7 @@ public class DigestAuthenticator implements CachingAuthenticator {
     }
 
 
-    private static class AuthenticationException extends IllegalStateException {
+    private static class AuthenticationException extends IOException {
         private static final long serialVersionUID = 1L;
 
         public AuthenticationException(String s) {

--- a/src/test/java/com/burgstaller/okhttp/digest/DigestAuthenticatorTest.java
+++ b/src/test/java/com/burgstaller/okhttp/digest/DigestAuthenticatorTest.java
@@ -180,7 +180,7 @@ public class DigestAuthenticatorTest {
         assertThat(authenticated).isNull();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IOException.class)
     public void testWWWAuthenticate__withInvalidWWWAuthHeader__shouldThrowException() throws Exception {
         Request dummyRequest = new Request.Builder()
                 .url("http://www.google.com")
@@ -196,7 +196,7 @@ public class DigestAuthenticatorTest {
                 .build();
         try {
             authenticator.authenticate(null, response);
-        } catch (IllegalArgumentException e) {
+        } catch (IOException e) {
             e.printStackTrace();
             throw e;
         }


### PR DESCRIPTION
  /**
   * Returns a request that includes a credential to satisfy an authentication challenge in
   * [response]. Returns null if the challenge cannot be satisfied.
   *
   * The route is best effort, it currently may not always be provided even when logically
   * available. It may also not be provided when an authenticator is re-used manually in an
   * application interceptor, such as when implementing client-specific retries.
   */
  @Throws(IOException::class)
  fun authenticate(route: Route?, response: Response): Request?

In order to match the requirement from OkHttp's authenticate method, it's required to throw an IOException instead of an IllegalArgumentException. In my case, it causes a crash on a server returning empty headers.