### PR TITLE
fix:Session cookie not set

### DIFF
--- a/src/main/java/com/burgstaller/okhttp/digest/DigestAuthenticator.java
+++ b/src/main/java/com/burgstaller/okhttp/digest/DigestAuthenticator.java
@@ -188,7 +188,13 @@ public class DigestAuthenticator implements CachingAuthenticator {
             throw new IOException("missing nonce in challenge header: " + header);
         }
 
-        return authenticateWithState(route, response.request(), parameters);
+        Request request = authenticateWithState(route, response.request(), parameters);
+        List<String> cookies = response.headers().values("Set-Cookie");
+        if (request != null && !cookies.isEmpty()) {
+            String cookie = cookies.get(0).split(";")[0];
+            return request.newBuilder().header("Cookie", cookie).build();
+        }
+        return request;
     }
 
     private String getHeaderName(int httpStatus) {


### PR DESCRIPTION
Not adding a session resulted in the server consistently returning 401

